### PR TITLE
Read configuration options from pyproject.toml

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,6 +1,6 @@
 - id: docformatter-conda
   name: docformatter-conda
-  entry: docformatter -i
+  entry: docformatter -i --config pyproject.toml
   language: conda
   description: "Formats docstrings to follow PEP 257."
   types: [python]


### PR DESCRIPTION
The pre-commit hook currently ignores configuration options in `pyproject.toml`. This PR adds the config option to load the configuration.