### PR TITLE
Add support for pyproject.toml configuation

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,7 +1,8 @@
 - id: docformatter-conda
   name: docformatter-conda
-  entry: docformatter -i
+  entry: docformatter
+  args: [-i]
   language: conda
   description: "Formats docstrings to follow PEP 257."
   types: [python]
-  additional_dependencies: []
+  additional_dependencies: [tomli]


### PR DESCRIPTION
Fixes #2 

Tested locally in `sql-compyre` using `pre-commit try-repo ../pre-commit-mirrors-docformatter docformatter-conda -a --verbose`. This also aligns with the upstream definition of having `-i` listed as an arg.